### PR TITLE
ci(lint): don't lint dependabot commit messages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   lint-commits:
     runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -75,6 +76,7 @@ jobs:
 
   lint-dockerfile:
     runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
We will need this to merge dependabot PR.